### PR TITLE
#32 - 사업자 관련 API 구현

### DIFF
--- a/src/main/kotlin/kr/co/shophub/shophub/business/model/Business.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/business/model/Business.kt
@@ -1,0 +1,26 @@
+package kr.co.shophub.shophub.business.model
+
+import jakarta.persistence.*
+import jakarta.validation.constraints.NotNull
+import kr.co.shophub.shophub.shop.model.Shop
+import kr.co.shophub.shophub.user.model.User
+
+@Entity
+class Business (
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "business_id")
+    var id: Long = 0L,
+
+    @field:NotNull
+    val businessNumber: String,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id")
+    var shop: Shop,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val seller: User
+
+)

--- a/src/main/kotlin/kr/co/shophub/shophub/business/repository/BusinessRepository.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/business/repository/BusinessRepository.kt
@@ -1,0 +1,6 @@
+package kr.co.shophub.shophub.business.repository
+
+import kr.co.shophub.shophub.business.model.Business
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface BusinessRepository : JpaRepository<Business, Long>

--- a/src/main/kotlin/kr/co/shophub/shophub/global/oauth/OAuthAttributes.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/global/oauth/OAuthAttributes.kt
@@ -63,7 +63,7 @@ class OAuthAttributes(
             profile = oAuth2UserInfo.getImageUrl(),
             userRole = UserRole.GUEST_BUYER,
             password = PasswordUtil.generateRandomPassword(),
-            telNum = ""
+            phoneNumber = ""
         )
     }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/global/oauth/OAuthAttributes.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/global/oauth/OAuthAttributes.kt
@@ -63,7 +63,6 @@ class OAuthAttributes(
             profile = oAuth2UserInfo.getImageUrl(),
             userRole = UserRole.GUEST_BUYER,
             password = PasswordUtil.generateRandomPassword(),
-            phoneNumber = ""
         )
     }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/global/oauth/OAuthAttributes.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/global/oauth/OAuthAttributes.kt
@@ -63,6 +63,7 @@ class OAuthAttributes(
             profile = oAuth2UserInfo.getImageUrl(),
             userRole = UserRole.GUEST_BUYER,
             password = PasswordUtil.generateRandomPassword(),
+            telNum = ""
         )
     }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/global/oauth/handler/OAuth2LoginSuccessHandler.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/global/oauth/handler/OAuth2LoginSuccessHandler.kt
@@ -38,7 +38,7 @@ class OAuth2LoginSuccessHandler(
 
     private fun isAlreadyJoin(user: CustomOAuth2User): Boolean {
         val existAlready = userRepository.existsByEmail(user.email)
-        val isAuthorized = user.role== UserRole.USER
+        val isAuthorized = user.role == UserRole.USER_BUYER || user.role == UserRole.USER_SELLER
         return existAlready && isAuthorized
     }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/dto/CreateShopRequest.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/dto/CreateShopRequest.kt
@@ -8,5 +8,6 @@ data class CreateShopRequest(
     val introduce : String,
     val hour : String,
     val hourDescription : String,
-    val telNum : String
+    val telNum : String,
+    val businessNumber: String,
 )

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/model/Shop.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/model/Shop.kt
@@ -3,6 +3,7 @@ package kr.co.shophub.shophub.shop.model
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
+import kr.co.shophub.shophub.business.model.Business
 import kr.co.shophub.shophub.global.model.BaseEntity
 import kr.co.shophub.shophub.product.model.product.Product
 import kr.co.shophub.shophub.shop.dto.ChangeShopRequest
@@ -45,6 +46,9 @@ class Shop(
 
     @OneToMany(mappedBy = "shop", cascade = [CascadeType.ALL], orphanRemoval = true)
     var tags: MutableList<ShopTag> = mutableListOf(),
+
+    @OneToOne(mappedBy = "shop", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var business: Business? = null,
 
     @Column(name = "is_deleted")
     private var deleted: Boolean = false
@@ -98,5 +102,9 @@ class Shop(
     fun cancelFollow() {
         this.followCnt--
         this.level = followCnt/10 + 1
+    }
+
+    fun addBusiness(savedBusiness: Business) {
+        this.business = savedBusiness
     }
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
@@ -44,7 +44,7 @@ class ShopService(
         )
         val savedBusiness = businessRepository.save(business)
         seller.addBusiness(savedBusiness)
-        shop.addBusiness(savedBusiness)
+        savedShop.addBusiness(savedBusiness)
 
         return ShopIdResponse(savedShop.id)
     }

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
@@ -1,5 +1,7 @@
 package kr.co.shophub.shophub.shop.service
 
+import kr.co.shophub.shophub.business.model.Business
+import kr.co.shophub.shophub.business.repository.BusinessRepository
 import kr.co.shophub.shophub.global.error.ResourceNotFoundException
 import kr.co.shophub.shophub.shop.dto.*
 import kr.co.shophub.shophub.shop.model.Shop
@@ -8,6 +10,8 @@ import kr.co.shophub.shophub.shop.model.ShopTag
 import kr.co.shophub.shophub.shop.repository.ShopImageRepository
 import kr.co.shophub.shophub.shop.repository.ShopRepository
 import kr.co.shophub.shophub.shop.repository.ShopTagRepository
+import kr.co.shophub.shophub.user.model.User
+import kr.co.shophub.shophub.user.repository.UserRepository
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
@@ -18,7 +22,9 @@ import org.springframework.transaction.annotation.Transactional
 class ShopService(
     private val shopRepository: ShopRepository,
     private val shopImageRepository: ShopImageRepository,
-    private val shopTagRepository: ShopTagRepository
+    private val shopTagRepository: ShopTagRepository,
+    private val userRepository: UserRepository,
+    private val businessRepository: BusinessRepository,
 ) {
 
     @Transactional
@@ -29,6 +35,16 @@ class ShopService(
         val savedShop = shopRepository.save(shop)
         replaceShopImages(savedShop, createShopRequest.images)
         replaceShopTags(savedShop, createShopRequest.tags)
+
+        val seller = getUser(sellerId)
+        val business = Business(
+            businessNumber = createShopRequest.businessNumber,
+            seller = seller,
+            shop = savedShop,
+        )
+        val savedBusiness = businessRepository.save(business)
+        seller.addBusiness(savedBusiness)
+        shop.addBusiness(savedBusiness)
 
         return ShopIdResponse(savedShop.id)
     }
@@ -88,6 +104,11 @@ class ShopService(
     fun findShop(shopId: Long): Shop {
         return shopRepository.findByIdAndDeletedIsFalse(shopId)
             ?: throw ResourceNotFoundException("존재하지 않는 상점입니다.")
+    }
+
+    private fun getUser(userId: Long): User {
+        return userRepository.findByIdAndDeletedIsFalse(userId)
+            ?: throw ResourceNotFoundException("유저를 찾을 수 없습니다.")
     }
 
     companion object {

--- a/src/main/kotlin/kr/co/shophub/shophub/user/dto/JoinRequest.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/dto/JoinRequest.kt
@@ -13,6 +13,5 @@ data class JoinRequest(
     val nickname: String,
     val role: UserRole,
 
-    val phoneNumber: String = "only-seller",
-    val bizNumber: String = "only-seller",
+    val phoneNumber: String = "",
 )

--- a/src/main/kotlin/kr/co/shophub/shophub/user/model/User.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/model/User.kt
@@ -27,7 +27,7 @@ class User(
     private var refreshToken: String = "empty",
     var providerId: String = "only-social",
     var profile: String = "only-social",
-    var phoneNumber: String,
+    var phoneNumber: String = "",
 
     @Column(name = "is_deleted")
     private var deleted: Boolean = false,

--- a/src/main/kotlin/kr/co/shophub/shophub/user/model/User.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/model/User.kt
@@ -27,7 +27,7 @@ class User(
     private var refreshToken: String = "empty",
     var providerId: String = "only-social",
     var profile: String = "only-social",
-    var telNum: String,
+    var phoneNumber: String,
 
     @Column(name = "is_deleted")
     private var deleted: Boolean = false,
@@ -41,7 +41,7 @@ class User(
     @OneToMany(mappedBy = "seller", cascade = [CascadeType.ALL], orphanRemoval = true)
     val businessList: MutableList<Business> = mutableListOf(),
 
-): BaseEntity() {
+    ): BaseEntity() {
     fun encodePassword(encoder: PasswordEncoder) {
         this.password = encoder.encode(password)
     }
@@ -55,7 +55,7 @@ class User(
         this.userRole = checkRole
         this.nickname = request.nickname
         this.password = request.password
-        this.telNum = request.phoneNumber
+        this.phoneNumber = request.phoneNumber
     }
 
     fun updateRole() {

--- a/src/main/kotlin/kr/co/shophub/shophub/user/model/User.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/model/User.kt
@@ -3,6 +3,7 @@ package kr.co.shophub.shophub.user.model
 import jakarta.persistence.*
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotNull
+import kr.co.shophub.shophub.business.model.Business
 import kr.co.shophub.shophub.global.model.BaseEntity
 import kr.co.shophub.shophub.global.oauth.OAuthAttributes
 import kr.co.shophub.shophub.user.dto.SocialJoinRequest
@@ -23,11 +24,10 @@ class User(
     @field:NotNull
     var nickname: String,
 
-    var refreshToken: String = "empty",
+    private var refreshToken: String = "empty",
     var providerId: String = "only-social",
     var profile: String = "only-social",
-    var telNum: String = "",
-    var bizNum: String = "",
+    var telNum: String,
 
     @Column(name = "is_deleted")
     private var deleted: Boolean = false,
@@ -37,6 +37,9 @@ class User(
 
     @Enumerated(EnumType.STRING)
     var providerType: ProviderType = ProviderType.NO_SOCIAL,
+
+    @OneToMany(mappedBy = "seller", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val businessList: MutableList<Business> = mutableListOf(),
 
 ): BaseEntity() {
     fun encodePassword(encoder: PasswordEncoder) {
@@ -53,15 +56,14 @@ class User(
         this.nickname = request.nickname
         this.password = request.password
         this.telNum = request.phoneNumber
-        this.bizNum = request.bizNumber
     }
 
     fun updateRole() {
         if (this.userRole == UserRole.GUEST_BUYER) {
-            this.userRole = UserRole.USER
+            this.userRole = UserRole.USER_BUYER
         }
         if (this.userRole == UserRole.GUEST_SELLER) {
-            this.userRole = UserRole.SELLER
+            this.userRole = UserRole.USER_SELLER
         }
     }
 
@@ -83,6 +85,11 @@ class User(
 
     fun softDelete() {
         this.deleted = true
+    }
+
+    fun addBusiness(business: Business) {
+        this.businessList.add(business)
+        this.userRole = UserRole.SELLER
     }
 
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/user/model/UserRole.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/model/UserRole.kt
@@ -1,9 +1,10 @@
 package kr.co.shophub.shophub.user.model
 
 enum class UserRole {
-    GUEST_SELLER,
     GUEST_BUYER,
-    USER,
+    GUEST_SELLER,
+    USER_BUYER,
+    USER_SELLER,
     SELLER,
     ADMIN,
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/user/service/AuthService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/service/AuthService.kt
@@ -137,6 +137,6 @@ class AuthService(
     }
 
     private fun isAuthenticated(user: User) =
-        user.userRole == UserRole.SELLER || user.userRole == UserRole.USER_BUYER || user.userRole == UserRole.USER_SELLER
+        user.userRole == UserRole.SELLER || user.userRole == UserRole.USER_BUYER
 
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/user/service/AuthService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/service/AuthService.kt
@@ -32,7 +32,7 @@ class AuthService(
             password = request.password,
             nickname = request.nickname,
             userRole = userRole,
-            telNum = telNum,
+            phoneNumber = telNum,
         )
         checkEmail(user.email)
         checkNickname(user.nickname)

--- a/src/main/kotlin/kr/co/shophub/shophub/user/service/AuthService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/service/AuthService.kt
@@ -26,11 +26,13 @@ class AuthService(
     @Transactional
     fun join(request: JoinRequest): UserResponse {
         val userRole = checkRole(request.role)
+        val telNum = checkTelNum(request)
         val user = User(
             email = request.email,
             password = request.password,
             nickname = request.nickname,
             userRole = userRole,
+            telNum = telNum,
         )
         checkEmail(user.email)
         checkNickname(user.nickname)
@@ -40,11 +42,18 @@ class AuthService(
     }
 
     private fun checkRole(role: UserRole): UserRole {
-        return if (role == UserRole.USER) {
+        return if (role == UserRole.USER_BUYER) {
             UserRole.GUEST_BUYER
         } else {
             UserRole.GUEST_SELLER
         }
+    }
+
+    private fun checkTelNum(request: JoinRequest): String {
+        if (request.role == UserRole.SELLER && request.phoneNumber == "") {
+            throw IllegalArgumentException("전화번호 입력해 주세요.")
+        }
+        return request.phoneNumber
     }
 
     @Transactional
@@ -128,6 +137,6 @@ class AuthService(
     }
 
     private fun isAuthenticated(user: User) =
-        user.userRole == UserRole.SELLER || user.userRole == UserRole.USER
+        user.userRole == UserRole.SELLER || user.userRole == UserRole.USER_BUYER || user.userRole == UserRole.USER_SELLER
 
 }

--- a/src/test/kotlin/kr/co/shophub/shophub/coupon/service/CouponServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/coupon/service/CouponServiceTest.kt
@@ -31,7 +31,8 @@ class CouponServiceTest : BehaviorSpec({
         introduce = "Shop Introduce",
         hour = "Shop Hour",
         hourDescription = "Shop Hour Description",
-        telNum = "123-456-7890"
+        telNum = "123-456-7890",
+        businessNumber = "bizNum"
     )
 
     val shopId = 1L

--- a/src/test/kotlin/kr/co/shophub/shophub/follow/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/follow/service/FollowServiceTest.kt
@@ -29,7 +29,7 @@ class FollowServiceTest : BehaviorSpec({
             email = "test@test.com",
             nickname = "name",
             password = "password",
-            telNum = "telNum"
+            phoneNumber = "phoneNumber"
         )
 
         val shop = Shop(

--- a/src/test/kotlin/kr/co/shophub/shophub/follow/service/FollowServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/follow/service/FollowServiceTest.kt
@@ -29,6 +29,7 @@ class FollowServiceTest : BehaviorSpec({
             email = "test@test.com",
             nickname = "name",
             password = "password",
+            telNum = "telNum"
         )
 
         val shop = Shop(

--- a/src/test/kotlin/kr/co/shophub/shophub/product/service/ProductServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/product/service/ProductServiceTest.kt
@@ -45,7 +45,8 @@ class ProductServiceTest : BehaviorSpec({
         introduce = "Shop Introduce",
         hour = "Shop Hour",
         hourDescription = "Shop Hour Description",
-        telNum = "123-456-7890"
+        telNum = "123-456-7890",
+        businessNumber = "bizNum"
     )
 
     val shopId = 1L

--- a/src/test/kotlin/kr/co/shophub/shophub/shop/service/ShopServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/shop/service/ShopServiceTest.kt
@@ -3,9 +3,12 @@ package kr.co.shophub.shophub.shop.service
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
+import kr.co.shophub.shophub.business.model.Business
+import kr.co.shophub.shophub.business.repository.BusinessRepository
 import kr.co.shophub.shophub.global.error.ResourceNotFoundException
 import kr.co.shophub.shophub.shop.dto.*
 import kr.co.shophub.shophub.shop.model.Shop
@@ -14,13 +17,16 @@ import kr.co.shophub.shophub.shop.model.ShopTag
 import kr.co.shophub.shophub.shop.repository.ShopImageRepository
 import kr.co.shophub.shophub.shop.repository.ShopRepository
 import kr.co.shophub.shophub.shop.repository.ShopTagRepository
-import java.util.*
+import kr.co.shophub.shophub.user.model.User
+import kr.co.shophub.shophub.user.repository.UserRepository
 
 class ShopServiceTest : BehaviorSpec({
     val shopRepository = mockk<ShopRepository>()
     val shopImageRepository = mockk<ShopImageRepository>()
     val shopTagRepository = mockk<ShopTagRepository>()
-    val shopService = ShopService(shopRepository, shopImageRepository, shopTagRepository)
+    val userRepository = mockk<UserRepository>()
+    val businessRepository = mockk<BusinessRepository>()
+    val shopService = ShopService(shopRepository, shopImageRepository, shopTagRepository, userRepository, businessRepository)
 
     val sellerId = 1L
     val notSellerId = 3L
@@ -32,7 +38,8 @@ class ShopServiceTest : BehaviorSpec({
         introduce = "Shop Introduce",
         hour = "Shop Hour",
         hourDescription = "Shop Hour Description",
-        telNum = "123-456-7890"
+        telNum = "123-456-7890",
+        businessNumber = "bizNum"
     )
 
     val shopId = 2L
@@ -49,6 +56,19 @@ class ShopServiceTest : BehaviorSpec({
         telNum = "987-654-3210"
     )
 
+    val seller = User(
+        email = "email",
+        password = "password",
+        nickname = "nickname",
+        telNum = "telNum"
+    )
+
+    val business = Business(
+        businessNumber = "bizNum",
+        seller = seller,
+        shop = shop,
+    )
+
     beforeTest {
         clearMocks(shopRepository, shopImageRepository, shopTagRepository)
     }
@@ -60,11 +80,20 @@ class ShopServiceTest : BehaviorSpec({
             every { shopRepository.save(any()) } returns shop
             every { shopImageRepository.saveAll(any<List<ShopImage>>()) } returns listOf(mockk())
             every { shopTagRepository.saveAll(any<List<ShopTag>>()) } returns listOf(mockk())
+            every { userRepository.findByIdAndDeletedIsFalse(sellerId) } returns seller
+            every { businessRepository.save(any()) } returns business
 
             val response = shopService.createShop(sellerId, createShopRequest)
 
             Then("ShopIdResponse를 반환해야 함") {
                 response shouldBe ShopIdResponse(shopId)
+            }
+
+            Then("올바른 비즈니스가 생성 된다.") {
+                seller.businessList.size shouldBe 1
+                seller.businessList[0].businessNumber shouldBe business.businessNumber
+                shop.business shouldNotBe null
+                shop.business?.businessNumber shouldBe business.businessNumber
             }
         }
 

--- a/src/test/kotlin/kr/co/shophub/shophub/shop/service/ShopServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/shop/service/ShopServiceTest.kt
@@ -60,7 +60,7 @@ class ShopServiceTest : BehaviorSpec({
         email = "email",
         password = "password",
         nickname = "nickname",
-        telNum = "telNum"
+        phoneNumber = "telNum"
     )
 
     val business = Business(

--- a/src/test/kotlin/kr/co/shophub/shophub/user/serivce/AuthServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/user/serivce/AuthServiceTest.kt
@@ -51,6 +51,7 @@ class AuthServiceTest : BehaviorSpec({
             email = "test@test.com",
             password = "password",
             nickname = "name",
+            telNum = "telNum",
         )
 
         When("정상 회원 가입 시도") {
@@ -149,6 +150,7 @@ class AuthServiceTest : BehaviorSpec({
             email = "test@test.com",
             password = "password",
             nickname = "name",
+            telNum = "telNum",
         )
 
         val tokenResponse = TokenResponse(

--- a/src/test/kotlin/kr/co/shophub/shophub/user/serivce/AuthServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/user/serivce/AuthServiceTest.kt
@@ -51,7 +51,7 @@ class AuthServiceTest : BehaviorSpec({
             email = "test@test.com",
             password = "password",
             nickname = "name",
-            telNum = "telNum",
+            phoneNumber = "telNum",
         )
 
         When("정상 회원 가입 시도") {
@@ -150,7 +150,7 @@ class AuthServiceTest : BehaviorSpec({
             email = "test@test.com",
             password = "password",
             nickname = "name",
-            telNum = "telNum",
+            phoneNumber = "telNum",
         )
 
         val tokenResponse = TokenResponse(

--- a/src/test/kotlin/kr/co/shophub/shophub/user/serivce/UserServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/user/serivce/UserServiceTest.kt
@@ -36,7 +36,7 @@ class UserServiceTest: BehaviorSpec({
             email = "test@test.com",
             password = "password",
             nickname = "name",
-            telNum = "telNum",
+            phoneNumber = "telNum",
         )
 
         val shopList = mutableListOf<Follow>()

--- a/src/test/kotlin/kr/co/shophub/shophub/user/serivce/UserServiceTest.kt
+++ b/src/test/kotlin/kr/co/shophub/shophub/user/serivce/UserServiceTest.kt
@@ -36,6 +36,7 @@ class UserServiceTest: BehaviorSpec({
             email = "test@test.com",
             password = "password",
             nickname = "name",
+            telNum = "telNum",
         )
 
         val shopList = mutableListOf<Follow>()


### PR DESCRIPTION
## 관련 이슈
<!-- 연관된 이슈를 링크해주세요. -->
- #32 

<br/>

## 구현한 내용 또는 수정한 내용
<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 혹은 gif 등을 활용해 자유롭게 보여주세요. -->
- 매장 등록시 사업자 정보 등록
- 사업자 등록 플로우 변경으로 유저 role 변경


<br/>


## 추가적으로 알리고 싶은 내용
- 사업자 번호 검증은 아예 다른 도메인으로 요청해야 해서 프론트쪽에서 처리해야하는 것 같은데 
  잘못 알고 있다면 알려주세요!

<br/>

## TODO / 고민하고 있는 것들
- 매장 등록하고 해당 매장과 셀러로 Business 엔티티를 만들어야 하기 때문에 Shop에는 Business가 null 입니다.
  혹시 이 부분에 대해 더 좋은 방법이 있다면 알려주세요!

<br/>

## 배포 Checklist
 <!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->
- [x] SecretKey 를 업데이트 해주세요
- [x] 본인을 Assign 해주세요.
- [x] 본인을 제외한 백엔드 개발자를 리뷰어로 지정해주세요.

<br/>
