### PR TITLE
#38 - EC2 서버 다운 문제 / 브랜치 선택 배포

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,8 +1,6 @@
 name: DEV) Push Docker Image And Deploy to EC2
 
 on:
-  push:
-    branches: [ "develop" ]
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -3,6 +3,11 @@ name: DEV) Push Docker Image And Deploy to EC2
 on:
   push:
     branches: [ "develop" ]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
 
 permissions:
   contents: read
@@ -15,7 +20,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.inputs.branch }}
+          ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -50,7 +55,7 @@ jobs:
 
       - name: Print branch & tag information
         run: |
-          echo "Current branch: ${{ github.event.inputs.branch }}"
+          echo "Current branch: ${{ github.event.inputs.branch || github.ref }}"
           echo "Current tag: ${{ steps.short_sha.outputs.sha_short }}"
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -28,11 +28,20 @@ jobs:
           java-version: 17
           distribution: 'temurin'
 
-      - name: Set up yml secrets file
+      - name: Set up yml ec2 dev file
         env:
           YAML_SECRET: ${{ secrets.YAML_EC2_DEV }}
           YAML_DIR: src/main/resources
           YAML_FILE_NAME: application-ec2-dev.yml
+        run: |
+          echo $YAML_SECRET | base64 --decode > $YAML_DIR/$YAML_FILE_NAME
+          echo "YAML_SECRET has been decoded and saved to $YAML_DIR/$YAML_FILE_NAME"
+
+      - name: Set up yml secrets file
+        env:
+          YAML_SECRET: ${{ secrets.YAML_SECRET }}
+          YAML_DIR: src/main/resources
+          YAML_FILE_NAME: application-secret.yml
         run: |
           echo $YAML_SECRET | base64 --decode > $YAML_DIR/$YAML_FILE_NAME
           echo "YAML_SECRET has been decoded and saved to $YAML_DIR/$YAML_FILE_NAME"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,7 +11,7 @@ spring:
         use_sql_comments: true
         format_sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
 
 logging:
   level:


### PR DESCRIPTION
## 관련 이슈
- #25 
- #38 

<br/>

## 구현한 내용 또는 수정한 내용
- 이번 스프린트(10.31) 때 ec2가 다운되어 테스트가 불가능하던 문제 해결
- 브랜치를 선택해 ec2에 배포할 수 있게 구현 (아직 ec2 서버가 develop과 prod로 나누어 배포하는 건 좀 더 자료를 찾아보고 구현 완료하겠습니다.)
- develop 브랜치에 push 시 자동 배포는 삭제했습니다.

<br/>


## 추가적으로 알리고 싶은 내용
![image](https://github.com/shophubkr/shophub-server/assets/69510442/82bb772c-4e2d-4c44-a6d8-0d637fd88e12)
- 배포에 사용할 workflow 파일을 설정합니다. (develop 서버에 배포한다면 develop workflow를 사용하면 될 것 같습니다.)
- 원하는 브랜치를 입력 후 run workflow를 누르면 됩니다.
<br/>

## TODO / 고민하고 있는 것들
- ec2 서버에 develop과 prod 서버를 분리해 배포하는 방식