### PR TITLE
#50 - 팔로우한 매장 정렬 조건 및 검색 조건 추가

### DIFF
--- a/src/main/kotlin/kr/co/shophub/shophub/follow/controller/FollowController.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/follow/controller/FollowController.kt
@@ -1,21 +1,17 @@
 package kr.co.shophub.shophub.follow.controller
 
 import kr.co.shophub.shophub.follow.dto.FollowPageResponse
+import kr.co.shophub.shophub.follow.dto.SortCondition
 import kr.co.shophub.shophub.follow.service.FollowService
 import kr.co.shophub.shophub.global.dto.CommonResponse
 import kr.co.shophub.shophub.global.dto.EmptyDto
 import kr.co.shophub.shophub.global.dto.PageInfo
 import kr.co.shophub.shophub.global.login.service.LoginService
 import kr.co.shophub.shophub.shop.dto.ShopListResponse
-import kr.co.shophub.shophub.shop.dto.ShopSimpleResponse
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/follow")
@@ -35,14 +31,15 @@ class FollowController(
 
     @GetMapping("/shops")
     fun getAllFollowShop(
-        @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC) pageable: Pageable
+        @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC) pageable: Pageable,
+        @RequestBody condition: SortCondition,
     ): CommonResponse<FollowPageResponse> {
 
         val userId = loginService.getLoginUserId()
-        val followShopPage = followService.getAllFollowShop(userId, pageable)
+        val followShopPage = followService.getAllFollowShop(userId, pageable, condition)
         return CommonResponse(
             result = FollowPageResponse(
-                shopListResponse = ShopListResponse(followShopPage.content.map { ShopSimpleResponse(it) }),
+                shopListResponse = ShopListResponse(followShopPage.content),
                 followCount = followShopPage.content.size),
             page = PageInfo.of(followShopPage)
         )

--- a/src/main/kotlin/kr/co/shophub/shophub/follow/dto/SortCondition.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/follow/dto/SortCondition.kt
@@ -1,0 +1,6 @@
+package kr.co.shophub.shophub.follow.dto
+
+data class SortCondition(
+    val hasCoupon: Boolean = false,
+    val isSortByMinPrice: Boolean = false,
+)

--- a/src/main/kotlin/kr/co/shophub/shophub/follow/service/FollowService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/follow/service/FollowService.kt
@@ -45,9 +45,9 @@ class FollowService(
 
     fun getAllFollowShop(userId: Long, pageable: Pageable, condition: SortCondition): Page<ShopSimpleResponse> {
         val user = getUser(userId)
-        val ids = user.userCoupon.map { it.coupon.shop.id }
+        val followShopIds = user.userCoupon.map { it.coupon.shop.id }
         var followedShops = followRepository.findByUser(user)
-            .map { ShopSimpleResponse(it.shop, ids) }
+            .map { ShopSimpleResponse(it.shop, followShopIds) }
             .sortedByDescending { it.id }
 
         if (condition.hasCoupon) {

--- a/src/main/kotlin/kr/co/shophub/shophub/follow/service/FollowService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/follow/service/FollowService.kt
@@ -45,9 +45,9 @@ class FollowService(
 
     fun getAllFollowShop(userId: Long, pageable: Pageable, condition: SortCondition): Page<ShopSimpleResponse> {
         val user = getUser(userId)
-        val followShopIds = user.userCoupon.map { it.coupon.shop.id }
+        val hasCouponShopIds = user.userCoupon.map { it.coupon.shop.id }
         var followedShops = followRepository.findByUser(user)
-            .map { ShopSimpleResponse(it.shop, followShopIds) }
+            .map { ShopSimpleResponse(it.shop, hasCouponShopIds) }
             .sortedByDescending { it.id }
 
         if (condition.hasCoupon) {

--- a/src/main/kotlin/kr/co/shophub/shophub/follow/service/FollowService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/follow/service/FollowService.kt
@@ -1,13 +1,16 @@
 package kr.co.shophub.shophub.follow.service
 
+import kr.co.shophub.shophub.follow.dto.SortCondition
 import kr.co.shophub.shophub.follow.model.Follow
 import kr.co.shophub.shophub.follow.repository.FollowRepository
 import kr.co.shophub.shophub.global.error.ResourceNotFoundException
+import kr.co.shophub.shophub.shop.dto.ShopSimpleResponse
 import kr.co.shophub.shophub.shop.model.Shop
 import kr.co.shophub.shophub.shop.repository.ShopRepository
 import kr.co.shophub.shophub.user.model.User
 import kr.co.shophub.shophub.user.repository.UserRepository
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -40,12 +43,32 @@ class FollowService(
         user: User
     ) = followRepository.existsByShopAndUser(shop, user)
 
-    fun getAllFollowShop(userId: Long, pageable: Pageable): Page<Shop> {
+    fun getAllFollowShop(userId: Long, pageable: Pageable, condition: SortCondition): Page<ShopSimpleResponse> {
         val user = getUser(userId)
-        return followRepository.findByUser(user, pageable)
-            .map { it.shop }
+        val ids = user.userCoupon.map { it.coupon.shop.id }
+        var followedShops = followRepository.findByUser(user)
+            .map { ShopSimpleResponse(it.shop, ids) }
+            .sortedByDescending { it.id }
 
+        if (condition.hasCoupon) {
+            followedShops = filterByHasCoupon(followedShops)
+        }
+        if (condition.isSortByMinPrice) {
+            followedShops = sortByMinPrice(followedShops)
+        }
+
+        return createPage(followedShops, pageable)
     }
+
+    private fun createPage(findByUser: List<ShopSimpleResponse>, pageable: Pageable): Page<ShopSimpleResponse> {
+        return PageImpl(findByUser, pageable, findByUser.size.toLong())
+    }
+
+    private fun filterByHasCoupon(list: List<ShopSimpleResponse>): List<ShopSimpleResponse> =
+        list.filter { it.checkCoupon }
+
+    private fun sortByMinPrice(list: List<ShopSimpleResponse>): List<ShopSimpleResponse> =
+        list.sortedBy { it.minPrice }
 
     private fun getUser(userId: Long): User {
         return userRepository.findByIdAndDeletedIsFalse(userId)

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/dto/ShopSimpleResponse.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/dto/ShopSimpleResponse.kt
@@ -20,4 +20,14 @@ data class ShopSimpleResponse(
         minPrice = shop.products.minByOrNull { it.price }?.price ?: 0,
         checkCoupon = true
     )
+
+    constructor(shop: Shop, ids: List<Long>) : this(
+        id = shop.id,
+        image = shop.images[0].imgUrl,
+        name = shop.name,
+        address = shop.address,
+        introduce = shop.introduce,
+        minPrice = shop.products.minByOrNull { it.price }?.price ?: 0,
+        checkCoupon = ids.contains(shop.id)
+    )
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/user/service/UserService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/service/UserService.kt
@@ -30,8 +30,9 @@ class UserService(
 
     fun getMyPage(userId: Long): MyPageResponse {
         val user = getUser(userId)
+        val followShopIds = user.userCoupon.map { it.coupon.shop.id }
         val shops = followRepository.findByUser(user)
-            .map { ShopSimpleResponse(it.shop) }
+            .map { ShopSimpleResponse(it.shop, followShopIds) }
         val coupons = mutableListOf<String>()
         return MyPageResponse(
             email = user.email,


### PR DESCRIPTION
## 관련 이슈
<!-- 연관된 이슈를 링크해주세요. -->
- #50 

<br/>

## 구현한 내용 또는 수정한 내용
<!-- 구현 내용을 리뷰어가 확인할 수 있도록 스크린샷 혹은 gif 등을 활용해 자유롭게 보여주세요. -->
- 쿠폰 보유 여부, 최저가 순으로 정렬 ->  2가지 구현했습니다.
- `QueryDsl`  사용해보려고 했는데 `minPrice`가 `ShopSimpleResponse`의 필드 값이라 프로젝션을 사용해야 할텐데 
   `QClass`로는 프로젝션이 힘들어서 우선 `FollowService`에서 정렬및 필터를 처리하는 방식으로 만들었습니다.
- 별로 좋은 방법 같지는 않습니다. 좋은 방법 알려주시면 참고해서 수정해보겠습니다!
- 추가로 `@PageableDefault ` 에서 아이디 내림차순으로 정렬했는데 serive로 넘어갔다 오니 적용이 안되는데 혹시 방법 아시는 분 있을까요?
-현재 포스트맨으로 동작하는 것은 확인했지만 놓친 부분이 있다면 알려주세요!

<br/>


## 추가적으로 알리고 싶은 내용
- 

<br/>

## TODO / 고민하고 있는 것들
- 

<br/>

## 배포 Checklist
 <!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->
- [ ] SecretKey 를 업데이트 해주세요
- [ ] 본인을 Assign 해주세요.
- [ ] 본인을 제외한 백엔드 개발자를 리뷰어로 지정해주세요.

<br/>
