### PR TITLE
#53 - 스케줄러를 통해 매일 자정 쿠폰 만료 업데이트 // 쿠폰 조회 쿼리 개선

### DIFF
--- a/src/main/kotlin/kr/co/shophub/shophub/ShopHubApplication.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/ShopHubApplication.kt
@@ -3,9 +3,11 @@ package kr.co.shophub.shophub
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class ShopHubApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/controller/CouponController.kt
@@ -13,12 +13,15 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.*
+import java.time.Clock
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1")
 class CouponController(
     private val couponService: CouponService,
     private val loginService: LoginService,
+    private val clock: Clock,
 ) {
 
     @PostMapping("/shops/{shopId}/coupons")
@@ -30,7 +33,8 @@ class CouponController(
         return couponService.createCoupon(
             createCouponRequest = createCouponRequest,
             userId = loginService.getLoginUserId(),
-            shopId = shopId
+            shopId = shopId,
+            nowDate = LocalDate.now(clock),
         ).let { CommonResponse(it) }
 
     }
@@ -39,15 +43,16 @@ class CouponController(
     fun getCouponList(
         @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC) pageable: Pageable,
         @PathVariable shopId: Long,
-        @RequestParam isFinished: Boolean = false,
+        @RequestParam isTerminated: Boolean = false,
     ): CommonResponse<CouponListResponse> {
         val couponList = couponService.getCouponList(
             shopId = shopId,
             pageable = pageable,
-            isFinished = isFinished,
+            isTerminated = isTerminated,
+            nowDate = LocalDate.now(clock),
         )
         return CommonResponse(
-            result = CouponListResponse(couponList.content.map { CouponResponse(it) }),
+            result = CouponListResponse(couponList.content.map { CouponResponse(it, clock) }),
             page = PageInfo.of(page = couponList)
         )
 
@@ -61,7 +66,8 @@ class CouponController(
         val userId = loginService.getLoginUserId()
         couponService.terminateCoupon(
             couponId = couponId,
-            userId = userId
+            userId = userId,
+            nowDate = LocalDate.now(clock),
         )
         return CommonResponse.EMPTY
 

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/controller/CouponController.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/controller/CouponController.kt
@@ -41,7 +41,6 @@ class CouponController(
         @PathVariable shopId: Long,
         @RequestParam isFinished: Boolean = false,
     ): CommonResponse<CouponListResponse> {
-
         val couponList = couponService.getCouponList(
             shopId = shopId,
             pageable = pageable,

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/dto/CouponResponse.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/dto/CouponResponse.kt
@@ -1,6 +1,7 @@
 package kr.co.shophub.shophub.coupon.dto
 
 import kr.co.shophub.shophub.coupon.model.Coupon
+import java.time.Clock
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
@@ -13,13 +14,13 @@ data class CouponResponse (
     val expiredAt: LocalDate,
     val dDay: Long,
 ){
-    constructor(coupon: Coupon): this(
+    constructor(coupon: Coupon, clock: Clock): this(
         id = coupon.id,
         content = coupon.content,
         detail = coupon.detail,
-        isFinished = coupon.isTerminated,
+        isFinished = LocalDate.now(clock).isAfter(coupon.expiredAt),
         startedAt = coupon.startedAt,
         expiredAt = coupon.expiredAt,
-        dDay = ChronoUnit.DAYS.between(LocalDate.now(), coupon.expiredAt)
+        dDay = ChronoUnit.DAYS.between(LocalDate.now(clock), coupon.expiredAt)
     )
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/model/Coupon.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/model/Coupon.kt
@@ -23,15 +23,11 @@ class Coupon(
     val startedAt: LocalDate,
 
     @field:NotNull
-    val expiredAt: LocalDate,
-
-    var isTerminated: Boolean = false,
+    var expiredAt: LocalDate,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id")
     var shop: Shop,
-
-    private var deleted: Boolean = false,
 
     ): BaseEntity() {
 
@@ -43,7 +39,7 @@ class Coupon(
         shop = shop,
     )
 
-    fun terminateCoupon() {
-        this.isTerminated = true
+    fun terminateCoupon(now: LocalDate) {
+        expiredAt = now.minusDays(1)
     }
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepository.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepository.kt
@@ -1,10 +1,7 @@
 package kr.co.shophub.shophub.coupon.repository
 
 import kr.co.shophub.shophub.coupon.model.Coupon
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface CouponRepository : JpaRepository<Coupon, Long>, CouponRepositoryCustom{
@@ -13,15 +10,7 @@ interface CouponRepository : JpaRepository<Coupon, Long>, CouponRepositoryCustom
         SELECT c
         FROM Coupon c
         JOIN FETCH c.shop
-        WHERE c.id = :couponId AND c.deleted = false
+        WHERE c.id = :couponId
     """)
-    fun findByCouponIdAndDeletedIsFalse(couponId: Long): Coupon?
-
-    @Modifying
-    @Query("""
-        UPDATE Coupon c 
-        SET c.isTerminated = true
-        WHERE NOW() > c.expiredAt
-    """)
-    fun updateCouponByExpiredAt()
+    fun findByCouponId(couponId: Long): Coupon?
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepository.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepository.kt
@@ -24,5 +24,4 @@ interface CouponRepository : JpaRepository<Coupon, Long>, CouponRepositoryCustom
         WHERE NOW() > c.expiredAt
     """)
     fun updateCouponByExpiredAt()
-    fun findAllByShopIdAndIsTerminatedAndDeletedIsFalse(shopId: Long, isTerminated: Boolean, pageable: Pageable): Page<Coupon>
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepository.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepository.kt
@@ -4,9 +4,10 @@ import kr.co.shophub.shophub.coupon.model.Coupon
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
-interface CouponRepository : JpaRepository<Coupon, Long> {
+interface CouponRepository : JpaRepository<Coupon, Long>, CouponRepositoryCustom{
 
     @Query("""
         SELECT c
@@ -15,5 +16,13 @@ interface CouponRepository : JpaRepository<Coupon, Long> {
         WHERE c.id = :couponId AND c.deleted = false
     """)
     fun findByCouponIdAndDeletedIsFalse(couponId: Long): Coupon?
+
+    @Modifying
+    @Query("""
+        UPDATE Coupon c 
+        SET c.isTerminated = true
+        WHERE NOW() > c.expiredAt
+    """)
+    fun updateCouponByExpiredAt()
     fun findAllByShopIdAndIsTerminatedAndDeletedIsFalse(shopId: Long, isTerminated: Boolean, pageable: Pageable): Page<Coupon>
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryCustom.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryCustom.kt
@@ -3,7 +3,8 @@ package kr.co.shophub.shophub.coupon.repository
 import kr.co.shophub.shophub.coupon.model.Coupon
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 
 interface CouponRepositoryCustom {
-    fun findByExpiredAt(shopId : Long, isTerminate : Boolean, pageable: Pageable) : Page<Coupon>
+    fun findByExpiredAt(shopId: Long, isTerminate: Boolean, nowDate: LocalDate, pageable: Pageable) : Page<Coupon>
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryCustom.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryCustom.kt
@@ -1,0 +1,9 @@
+package kr.co.shophub.shophub.coupon.repository
+
+import kr.co.shophub.shophub.coupon.model.Coupon
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+
+interface CouponRepositoryCustom {
+    fun findByExpiredAt(shopId : Long, isTerminate : Boolean, pageable: Pageable) : Page<Coupon>
+}

--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryImpl.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryImpl.kt
@@ -1,0 +1,56 @@
+package kr.co.shophub.shophub.coupon.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import kr.co.shophub.shophub.coupon.model.Coupon
+import kr.co.shophub.shophub.coupon.model.QCoupon.coupon
+import kr.co.shophub.shophub.global.error.ResourceNotFoundException
+import kr.co.shophub.shophub.shop.model.QShop.shop
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+
+class CouponRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CouponRepositoryCustom{
+
+    override fun findByExpiredAt(shopId: Long, isTerminate: Boolean, pageable: Pageable): Page<Coupon> {
+
+        val contents = queryFactory
+            .selectFrom(coupon)
+            .join(coupon.shop, shop).fetchJoin()
+            .where(
+                shopIdEq(shopId),
+                isTerminateEq(isTerminate),
+                isNotDeleted()
+            )
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .orderBy(coupon.id.desc())
+            .fetch()
+
+        val total = queryFactory
+            .select(coupon.count())
+            .from(coupon)
+            .leftJoin(coupon.shop, shop)
+            .where(
+                shopIdEq(shopId),
+                isTerminateEq(isTerminate)
+            )
+            .fetchOne() ?: throw ResourceNotFoundException("")
+
+
+        return PageImpl(contents, pageable, total)
+    }
+
+    private fun isNotDeleted(): BooleanExpression {
+        return coupon.deleted.isFalse
+    }
+
+    private fun shopIdEq(shopId: Long): BooleanExpression =
+        coupon.shop.id.eq(shopId)
+
+    private fun isTerminateEq(isTerminate: Boolean): BooleanExpression =
+        coupon.isTerminated.eq(isTerminate)
+
+}

--- a/src/main/kotlin/kr/co/shophub/shophub/global/config/TimeConfig.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/global/config/TimeConfig.kt
@@ -1,0 +1,14 @@
+package kr.co.shophub.shophub.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class TimeConfig {
+
+    @Bean
+    fun clock(): Clock{
+        return Clock.systemDefaultZone()
+    }
+}

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/model/Shop.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/model/Shop.kt
@@ -3,6 +3,7 @@ package kr.co.shophub.shophub.shop.model
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
+import kr.co.shophub.shophub.business.model.Business
 import kr.co.shophub.shophub.coupon.model.Coupon
 import kr.co.shophub.shophub.global.model.BaseEntity
 import kr.co.shophub.shophub.product.model.product.Product
@@ -51,7 +52,10 @@ class Shop(
     var tags: MutableList<ShopTag> = mutableListOf(),
 
     @Column(name = "is_deleted")
-    private var deleted: Boolean = false
+    private var deleted: Boolean = false,
+
+    @OneToOne(mappedBy = "shop", cascade = [CascadeType.ALL], orphanRemoval = true)
+    var business: Business? = null,
 
 ) : BaseEntity() {
     constructor(createShopRequest: CreateShopRequest, sellerId: Long) : this(
@@ -108,4 +112,7 @@ class Shop(
         this.level = followCnt/10 + 1
     }
 
+    fun addBusiness(savedBusiness: Business) {
+        this.business = savedBusiness
+    }
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/model/Shop.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/model/Shop.kt
@@ -3,7 +3,6 @@ package kr.co.shophub.shophub.shop.model
 import jakarta.persistence.*
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
-import kr.co.shophub.shophub.business.model.Business
 import kr.co.shophub.shophub.coupon.model.Coupon
 import kr.co.shophub.shophub.global.model.BaseEntity
 import kr.co.shophub.shophub.product.model.product.Product
@@ -50,9 +49,6 @@ class Shop(
 
     @OneToMany(mappedBy = "shop", cascade = [CascadeType.ALL], orphanRemoval = true)
     var tags: MutableList<ShopTag> = mutableListOf(),
-
-    @OneToOne(mappedBy = "shop", cascade = [CascadeType.ALL], orphanRemoval = true)
-    var business: Business? = null,
 
     @Column(name = "is_deleted")
     private var deleted: Boolean = false
@@ -112,7 +108,4 @@ class Shop(
         this.level = followCnt/10 + 1
     }
 
-    fun addBusiness(savedBusiness: Business) {
-        this.business = savedBusiness
-    }
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
@@ -44,6 +44,7 @@ class ShopService(
         )
         val savedBusiness = businessRepository.save(business)
         seller.addBusiness(savedBusiness)
+        savedShop.addBusiness(savedBusiness)
 
         return ShopIdResponse(savedShop.id)
     }

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/service/ShopService.kt
@@ -44,7 +44,6 @@ class ShopService(
         )
         val savedBusiness = businessRepository.save(business)
         seller.addBusiness(savedBusiness)
-        savedShop.addBusiness(savedBusiness)
 
         return ShopIdResponse(savedShop.id)
     }

--- a/src/main/kotlin/kr/co/shophub/shophub/test/TestController.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/test/TestController.kt
@@ -10,8 +10,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/test")
-class TestController(
-) {
+class TestController {
     @GetMapping("/illegal-argument")
     fun triggerIllegalArgumentException(): String {
         throw IllegalArgumentException("Illegal argument provided!")

--- a/src/main/kotlin/kr/co/shophub/shophub/user/controller/UserController.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/controller/UserController.kt
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.*
+import java.time.Clock
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -18,6 +20,7 @@ class UserController(
     private val loginService: LoginService,
     private val userService: UserService,
     private val mailService: MailService,
+    private val clock: Clock
 ) {
 
     @GetMapping("/me")
@@ -32,7 +35,7 @@ class UserController(
         @PageableDefault(sort = ["id"], direction = Sort.Direction.DESC) pageable: Pageable,
     ): CommonResponse<UserCouponListResponse>{
         val userId = getLoginId()
-        val myCoupons = userService.getMyCoupons(userId, status, pageable)
+        val myCoupons = userService.getMyCoupons(userId, status, pageable, LocalDate.now(clock))
         return CommonResponse(myCoupons)
     }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/user/repository/UserCouponCustomRepository.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/repository/UserCouponCustomRepository.kt
@@ -4,7 +4,8 @@ import kr.co.shophub.shophub.user.model.UserCoupon
 import kr.co.shophub.shophub.user.model.UserCouponCond
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import java.time.LocalDate
 
 interface UserCouponCustomRepository {
-    fun findUserCoupons(userId: Long, status: UserCouponCond, pageable: Pageable): Page<UserCoupon>
+    fun findUserCoupons(userId: Long, status: UserCouponCond, pageable: Pageable, nowDate: LocalDate): Page<UserCoupon>
 }

--- a/src/main/kotlin/kr/co/shophub/shophub/user/repository/UserCouponCustomRepositoryImpl.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/repository/UserCouponCustomRepositoryImpl.kt
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
-import java.time.LocalDate
 
 @Repository
 class UserCouponCustomRepositoryImpl (
@@ -42,8 +41,8 @@ class UserCouponCustomRepositoryImpl (
     private fun couponSearchCond(status: UserCouponCond): BooleanExpression =
         when (status) {
             UserCouponCond.USED -> userCoupon.isUsed.isTrue
-            UserCouponCond.UNUSED -> userCoupon.isUsed.isFalse
-            UserCouponCond.EXPIRED -> coupon.expiredAt.before(LocalDate.now()).or(coupon.isTerminated.isTrue)
+            UserCouponCond.UNUSED -> userCoupon.isUsed.isFalse.and(coupon.isTerminated.isFalse)
+            UserCouponCond.EXPIRED -> userCoupon.isUsed.isFalse.and(coupon.isTerminated.isTrue)
         }
 }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/user/repository/UserCouponCustomRepositoryImpl.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/repository/UserCouponCustomRepositoryImpl.kt
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 class UserCouponCustomRepositoryImpl (
@@ -20,14 +21,15 @@ class UserCouponCustomRepositoryImpl (
     override fun findUserCoupons(
         userId: Long,
         status: UserCouponCond,
-        pageable: Pageable
+        pageable: Pageable,
+        nowDate: LocalDate,
     ): Page<UserCoupon> {
         val contents = queryFactory.selectFrom(userCoupon)
             .join(userCoupon.coupon, coupon).fetchJoin()
             .join(coupon.shop, shop).fetchJoin()
             .where(
                 userCoupon.user.id.eq(userId).and(
-                    couponSearchCond(status)
+                    couponSearchCond(status, nowDate)
                 )
             )
             .offset(pageable.offset)
@@ -38,11 +40,11 @@ class UserCouponCustomRepositoryImpl (
 
         return PageImpl(contents)
     }
-    private fun couponSearchCond(status: UserCouponCond): BooleanExpression =
+    private fun couponSearchCond(status: UserCouponCond, nowDate: LocalDate): BooleanExpression =
         when (status) {
             UserCouponCond.USED -> userCoupon.isUsed.isTrue
-            UserCouponCond.UNUSED -> userCoupon.isUsed.isFalse.and(coupon.isTerminated.isFalse)
-            UserCouponCond.EXPIRED -> userCoupon.isUsed.isFalse.and(coupon.isTerminated.isTrue)
+            UserCouponCond.UNUSED -> userCoupon.isUsed.isFalse.and(coupon.expiredAt.before(nowDate).or(coupon.expiredAt.eq(nowDate)))
+            UserCouponCond.EXPIRED -> userCoupon.isUsed.isFalse.and(coupon.expiredAt.after(nowDate))
         }
 }
 

--- a/src/main/kotlin/kr/co/shophub/shophub/user/service/UserService.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/user/service/UserService.kt
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import kotlin.jvm.optionals.getOrNull
 
 @Service
@@ -40,9 +41,14 @@ class UserService(
         )
     }
 
-    fun getMyCoupons(userId: Long, status: UserCouponCond, pageable: Pageable): UserCouponListResponse{
+    fun getMyCoupons(
+        userId: Long,
+        status: UserCouponCond,
+        pageable: Pageable,
+        nowDate: LocalDate,
+        ): UserCouponListResponse{
         val userCoupons =
-            userCouponRepository.findUserCoupons(userId, status, pageable)
+            userCouponRepository.findUserCoupons(userId, status, pageable, nowDate)
                 .map { userCoupon -> UserCouponResponse(userCoupon) }
 
         return UserCouponListResponse(userCoupons, userCoupons.content.size)
@@ -89,7 +95,7 @@ class UserService(
     }
 
     private fun findCoupon(couponId: Long): Coupon {
-        return couponRepository.findByCouponIdAndDeletedIsFalse(couponId)
+        return couponRepository.findByCouponId(couponId)
             ?: throw ResourceNotFoundException("쿠폰 정보를 찾을 수 없습니다.")
     }
 


### PR DESCRIPTION
## 관련 이슈
- #53 

<br/>

## 구현한 내용 또는 수정한 내용
- 쿠폰이 자정이 지나면 자동으로 만료 필드가 바뀔 수 있게 변경 -> 스케줄러 사용
- 쿠폰 생성 로직에 오늘 날짜보다 과거의 날짜가 들어오면 에러를 발생하는 로직을 추가

<br/>


## 추가적으로 알리고 싶은 내용
- 원래 곧장 스케줄러를 사용하려 했던 것은 아니었습니다. 현재 날짜를 가져와서 QueryDsl을 통해 현재날짜와 만료날짜를 계산하여 검색을 하려고 했는데, '애초에 계산을 해서 가져오는 것보다 자정마다 만료 여부를 업데이트하여 가져오는 게 더 낫지 않을까?'라는 생각에 스케줄러를 도입했습니다. 
- 그런데 생각보다는 그렇게 성능이 증가하진 않더군요..

- 현재 시간을 가져와서 검증하는 로직을 테스트하기 위해 TimeConfig를 만들었습니다. 이렇게 쓰니 실제 서비스에서는 현재 시간을 가져오고 테스트에서는 제가 임의로 지정한 시간을 사용할 수 있게 되었습니다.
<br/>

## TODO / 고민하고 있는 것들
- 왜 성능의 차이가 그렇게 크지 않았을지 고민입니다. 
## 고민의 결과(?)
- 일단 여러 자료들을 좀 찾아보았습니다. 결론적으로 이전의 방식(현재 날짜의 값을 통해 만료 날짜와 비교해서 가져오는 방식)을 가져가려고 합니다. 스케줄링에 대해 생각해보니 데이터가 많아지면 자정마다 데이터를 업데이트 할 때 테이블에 락이 걸리는 시간이 길어져 나중에는 큰 장애로 발생할 수 있다고 하네요. 무엇보다도 두 방법 모두 어쨌든 쿠폰 테이블을 풀스캔을 해야 하는 방식이라 큰 성능의 차이가 없다고 생각합니다.

<br/>

## 배포 Checklist
 <!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->
- [X] SecretKey 를 업데이트 해주세요
- [X] 본인을 Assign 해주세요.
- [X] 본인을 제외한 백엔드 개발자를 리뷰어로 지정해주세요.

<br/>
