### PR TITLE
#67 - 매장 조회 응답값 쿠폰 여부 로직 추가

### DIFF
--- a/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryImpl.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/coupon/repository/CouponRepositoryImpl.kt
@@ -7,8 +7,8 @@ import kr.co.shophub.shophub.coupon.model.QCoupon.coupon
 import kr.co.shophub.shophub.global.error.ResourceNotFoundException
 import kr.co.shophub.shophub.shop.model.QShop.shop
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
 import java.time.LocalDate
 
 class CouponRepositoryImpl(
@@ -37,15 +37,14 @@ class CouponRepositoryImpl(
         val total = queryFactory
             .select(coupon.count())
             .from(coupon)
-            .leftJoin(coupon.shop, shop)
             .where(
                 shopIdEq(shopId),
                 isFinished(nowDate, isTerminate),
             )
-            .fetchOne() ?: throw ResourceNotFoundException("쿠폰이 존재하지 않습니다.")
 
-
-        return PageImpl(contents, pageable, total)
+        return PageableExecutionUtils.getPage(contents, pageable) {
+            total.fetchOne() ?: throw ResourceNotFoundException("쿠폰이 존재하지 않습니다.")
+        }
     }
 
     override fun findShortestExpirationCoupons(shopId: Long, nowDate: LocalDate): Coupon {

--- a/src/main/kotlin/kr/co/shophub/shophub/shop/dto/ShopSimpleResponse.kt
+++ b/src/main/kotlin/kr/co/shophub/shophub/shop/dto/ShopSimpleResponse.kt
@@ -18,7 +18,7 @@ data class ShopSimpleResponse(
         address = shop.address,
         introduce = shop.introduce,
         minPrice = shop.products.minByOrNull { it.price }?.price ?: 0,
-        checkCoupon = true
+        checkCoupon = shop.coupons.isNotEmpty()
     )
 
     constructor(shop: Shop, ids: List<Long>) : this(


### PR DESCRIPTION
## 관련 이슈
- #67 

<br/>

## 구현한 내용 또는 수정한 내용
- 매장 조회 응답 DTO에 checkCoupon로직이 true로만 반환되던 부분에 로직 추가
- coupon 페이징 개선


<br/>


## 추가적으로 알리고 싶은 내용
- shop과 coupon을 한번에 가져오면 쿼리 수를 줄일 수 있겠지만.. 곧 MSA를 적용한다면 의미가 없어질 것 같아 위 상태로 둡니다.

<br/>

## TODO / 고민하고 있는 것들
- 

<br/>

## 배포 Checklist
 <!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->
- [X] SecretKey 를 업데이트 해주세요
- [X] 본인을 Assign 해주세요.
- [X] 본인을 제외한 백엔드 개발자를 리뷰어로 지정해주세요.

<br/>
